### PR TITLE
Replacing deprecated request-module with node-fetch and adding package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ For every column it checks if a valid DateTime is given, and then formats it to 
 ## Installation
 ````
 git clone https://github.com/timdows/MMM-JsonTable.git
+cd MMM-JsonTable
+npm install
 ````
 
 ## Config Options

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,5 @@
 var NodeHelper = require('node_helper');
-var request = require('request');
+var fetch = require('node-fetch');
 
 module.exports = NodeHelper.create({
 	start: function () {
@@ -9,12 +9,9 @@ module.exports = NodeHelper.create({
 	getJson: function (url) {
 		var self = this;
 
-		request({ url: url, method: 'GET' }, function (error, response, body) {
-			if (!error && response.statusCode == 200) {
-				var json = JSON.parse(body);
-				// Send the json data back with the url to distinguish it on the receiving part
-				self.sendSocketNotification("MMM-JsonTable_JSON_RESULT", {url: url, data: json});
-			}
+		fetch(url).then(response => response.json()).then(json => {
+			// Send the json data back with the url to distinguish it on the receiving part
+			self.sendSocketNotification("MMM-JsonTable_JSON_RESULT", {url: url, data: json});
 		});
 
 	},

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mmm-jsontable",
+  "version": "1.0.0",
+  "description": "A module for the MagicMirror project which creates a table filled with a list gathered from a json request.",
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  }
+}


### PR DESCRIPTION
When I upgraded to the latest MagicMirror this module stopped working, this seems to be be because of MagicMirror getting rid of a deprecated dependency ```request``` which this module also uses (see https://github.com/MichMich/MagicMirror/issues/2617).

- Modified to use node-fetch which is a dependency that MagicMirror already has
- Added a minimal package.json to describe the dependencies this module uses to prevent the same kind of failure in a new release