### PR TITLE
Switch dependabot interval to "monthly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
That will be enough, and it also means we won't be bothered with small dependency updates so often.