### PR TITLE
change to support multiple instances even with same url

### DIFF
--- a/MMM-JsonTable.js
+++ b/MMM-JsonTable.js
@@ -31,14 +31,14 @@ Module.register("MMM-JsonTable", {
 
   // Request node_helper to get json from url
   getJson () {
-    this.sendSocketNotification("MMM-JsonTable_GET_JSON", this.config.url);
+    this.sendSocketNotification("MMM-JsonTable_GET_JSON", {url:this.config.url,id:this.identifier});
   },
 
   socketNotificationReceived (notification, payload) {
     if (notification === "MMM-JsonTable_JSON_RESULT") {
       // Only continue if the notification came from the request we made
       // This way we can load the module more than once
-      if (payload.url === this.config.url) {
+      if (payload.id === this.identifier) {
         this.jsonData = payload.data;
         this.updateDom(this.config.animationSpeed);
       }

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,24 +6,24 @@ module.exports = NodeHelper.create({
     Log.log("MMM-JsonTable helper started...");
   },
 
-  getJson (url) {
+  getJson (payload) {
     const self = this;
 
-    fetch(url)
+    fetch(payload.url)
       .then((response) => response.json())
       .then((json) => {
         // Send the json data back with the url to distinguish it on the receiving part
         self.sendSocketNotification("MMM-JsonTable_JSON_RESULT", {
-          url,
+          id:payload.id,
           data: json
         });
       });
   },
 
   // Subclass socketNotificationReceived received.
-  socketNotificationReceived (notification, url) {
+  socketNotificationReceived (notification, payload ) {
     if (notification === "MMM-JsonTable_GET_JSON") {
-      this.getJson(url);
+      this.getJson(payload);
     }
   }
 });


### PR DESCRIPTION
I changed the way you check multi-instance, by using the module identifier instead of the URL.
send ident with url,
send ident back with data
check that ident matches in module, instead of URL. 

a user had three arrays in the same json file and wanted to show them separately.
see https://forum.magicmirror.builders/topic/19690/module-to-display-json-data-from-a-file

